### PR TITLE
Add a 'Retrying' message to request_until_succeed()

### DIFF
--- a/get_fb_comments_from_fb.py
+++ b/get_fb_comments_from_fb.py
@@ -23,6 +23,7 @@ def request_until_succeed(url):
             time.sleep(5)
             
             print "Error for URL %s: %s" % (url, datetime.datetime.now())
+            print "Retrying."
             
             if '400' in str(e):
             	return None;

--- a/get_fb_posts_fb_group.py
+++ b/get_fb_posts_fb_group.py
@@ -23,6 +23,7 @@ def request_until_succeed(url):
             time.sleep(5)
             
             print "Error for URL %s: %s" % (url, datetime.datetime.now())
+            print "Retrying."
 
     return response.read()
 

--- a/get_fb_posts_fb_page.py
+++ b/get_fb_posts_fb_page.py
@@ -23,6 +23,7 @@ def request_until_succeed(url):
             time.sleep(5)
             
             print "Error for URL %s: %s" % (url, datetime.datetime.now())
+            print "Retrying."
 
     return response.read()
 


### PR DESCRIPTION
When the `request_until_succeed` function hits an exception, it rightly retries the request. Yet, it does not reassure the user that it does so, and the user may be worried that the scraper did not retrieve all data.

This pull request simply makes all three scripts `print "Retrying."` if `request_until_succeed` retries a request.