### PR TITLE
Accept unknown authors

### DIFF
--- a/get_fb_comments_from_fb.py
+++ b/get_fb_comments_from_fb.py
@@ -90,7 +90,7 @@ def processFacebookComment(comment, status_id, parent_id=''):
     comment_id = comment['id']
     comment_message = '' if 'message' not in comment or comment['message'] \
         is '' else unicode_decode(comment['message'])
-    comment_author = unicode_decode(comment['from']['name'])
+    comment_author = unicode_decode(comment['from'].get('name', 'Unknown'))
     num_reactions = 0 if 'reactions' not in comment else \
         comment['reactions']['summary']['total_count']
 

--- a/get_fb_posts_fb_group.py
+++ b/get_fb_posts_fb_group.py
@@ -113,7 +113,7 @@ def processFacebookPageFeedStatus(status):
         datetime.timedelta(hours=-5)  # EST
     status_published = status_published.strftime(
         '%Y-%m-%d %H:%M:%S')  # best time format for spreadsheet programs
-    status_author = unicode_decode(status['from']['name'])
+    status_author = unicode_decode(status['from'].get('name', 'Unknown'))
 
     # Nested items require chaining dictionary keys.
 


### PR DESCRIPTION
The parser fails when a post author name is missing.
To prevent the parser failing, we add Unknown as a name.