### PR TITLE
Bugfix for missing comments

### DIFF
--- a/get_fb_comments_from_fb.py
+++ b/get_fb_comments_from_fb.py
@@ -143,6 +143,7 @@ def scrapeFacebookPageFeedComments(page_id, access_token):
 
             for status in reader:
                 has_next_page = True
+                after = ''
 
                 while has_next_page:
 


### PR DESCRIPTION
When scraping multiple posts in a row, any post that is scraped after a post with paged comments had a malformed base_url, containing multiple "&after=" parameters. Because of this, apparently only the last page of comments was scraped for all subsequent posts.
Resetting the "after" variable at the start of the loop fixes this. In the for-loop for subcomments this was already implemented correctly.